### PR TITLE
Choiceモデル、user_idの外部キー追加。 #61

### DIFF
--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -43,7 +43,7 @@ class MicropostsController < ApplicationController
   private
 
     def micropost_params
-      params.require(:micropost).permit(:content, images: [], choices_attributes: [:id,:name, :_destroy])
+      params.require(:micropost).permit(:content, images: [], choices_attributes: [:id,:name, :user_id, :_destroy])
     end
 
     def set_micropost

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -2,4 +2,5 @@ class Choice < ApplicationRecord
   belongs_to :micropost
   has_many :votes, dependent: :destroy
   validates_presence_of :micropost
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :choices
   has_many :microposts, dependent: :destroy
   has_many :votes
   has_many :active_relationships, class_name: "Relationship",

--- a/app/views/microposts/_choice_fields.html.erb
+++ b/app/views/microposts/_choice_fields.html.erb
@@ -1,5 +1,6 @@
 <div class="nested-fields col-md-12">
   <%= f.text_area :name, class: "number" %>
+  <%= f.hidden_field :user_id, value: current_user.id %>
   <div class="judgement-btn">
     <%= link_to_remove_association "削除", f, data: { confirm: "『#{f.object.name}』を削除しますか？", cancel: 'やめる', title: '削除確認' }, class: "btn-border-sm"%>
     <%= f.submit "update?", class: "btn-border" %>

--- a/db/migrate/20200918111039_add_user_ref_to_choices.rb
+++ b/db/migrate/20200918111039_add_user_ref_to_choices.rb
@@ -1,0 +1,5 @@
+class AddUserRefToChoices < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :choices, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_170245) do
+ActiveRecord::Schema.define(version: 2020_09_18_111039) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -38,7 +38,9 @@ ActiveRecord::Schema.define(version: 2020_08_09_170245) do
     t.bigint "micropost_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["micropost_id"], name: "index_choices_on_micropost_id"
+    t.index ["user_id"], name: "index_choices_on_user_id"
   end
 
   create_table "microposts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -83,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_08_09_170245) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "choices", "microposts"
+  add_foreign_key "choices", "users"
   add_foreign_key "microposts", "users"
   add_foreign_key "relationships", "users", column: "followed_id"
   add_foreign_key "relationships", "users", column: "follower_id"


### PR DESCRIPTION
Choiceモデルにuser_idの外部キーを追加し、choiceボタンを押すと自分のuser_idが

DBに保存される仕様にしました。


close #61 