### PR TITLE
choicesモデルのnameカラムnull制約追加#78

### DIFF
--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -27,11 +27,14 @@ class MicropostsController < ApplicationController
   end
 
   def update
-    if @micropost.update(micropost_params)
+    if @micropost.update(micropost_params) then
       flash[:success] = "更新しました"
-      redirect_to micropost_path
-    else
+      redirect_to micropost_path  
+    elsif
+      @micropost.user == current_user then
       render 'edit'
+    else
+      render 'show'
     end
     if image = params[:micropost][:image_ids]
       image.each do |image_id|

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -2,5 +2,6 @@ class Choice < ApplicationRecord
   belongs_to :micropost
   has_many :votes, dependent: :destroy
   validates_presence_of :micropost
+  validates :name, presence: true, length: { maximum: 140 }
   belongs_to :user
 end

--- a/app/views/microposts/edit.html.erb
+++ b/app/views/microposts/edit.html.erb
@@ -2,7 +2,6 @@
 <%= form_with model: @micropost, local: true do |f|%>
   <div class="container_show">
     <div class="<%= @colors.sample %>">
-      <%= render 'shared/error_messeges', object: f.object%>
       <div class= "user_info">
         <%= gravatar_for @micropost.user %>
         <span class="user"><%= @micropost.user.name %></span>
@@ -17,6 +16,7 @@
       <% end %>
       <%= f.file_field :images, multiple: true %>
       <%= f.text_area :content, placeholder: "コメントを記入して下さい",class: "content" %>
+      <%= render 'shared/error_messeges', object: f.object%>
       <div id="detail-association-insertion-point">
         <div class="judgement-btn">
           <%= link_to_add_association 'ボタンを追加', f, :choices,

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -20,6 +20,7 @@
       <p><%= @micropost.content %></p>
     </div>
     <%= form_with model: @micropost, local: true do |f|%>
+    <%= render 'shared/error_messeges', object: f.object%>
       <div id="detail-association-insertion-point">
         <div class="judgement-btn">
           <%= link_to_add_association 'ボタンを追加', f, :choices,

--- a/db/migrate/20200922175925_change_column_notnull_onchoices.rb
+++ b/db/migrate/20200922175925_change_column_notnull_onchoices.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNotnullOnchoices < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :choices, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_111039) do
+ActiveRecord::Schema.define(version: 2020_09_22_175925) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2020_09_18_111039) do
   end
 
   create_table "choices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "name"
+    t.text "name", null: false
     t.bigint "micropost_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
choiceボタンを作成する時、空白を登録させない為に、

nameカラムに、null制約追加。

choicesモデルにバリデーション設定。

バリデーションエラー時、if文の分岐でリダイレクト先を変える様に設定しました。

自分の投稿のchoiceボタン作成、バリデーションエラー時のリダイレクト先は、edit画面

他人の投稿のchoiceボタン作成、バリデーションエラー時のリダイレクト先は、show画面

close #79 