### PR TITLE
プロフィール文保存、その他修正。#88

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,19 +35,14 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    if @user.update_attributes(user_params)
-      flash[:succces] = "編集しました"
-      redirect_to @user
-    elsif params[:user][:profile_image].present?
-      @user = User.find(params[:id])
-      @user.profile_image.attach(params[:user][:profile_image])
-      flash[:succces] = "編集しました"
-      redirect_to @user
-    elsif params[:user][:avatar].present?
-      @user = User.find(params[:id])
-      @user.avatar.attach(params[:user][:avatar])
-      flash[:succces] = "編集しました"
-      redirect_to @user
+    @user.attributes = user_params
+    if @user.save(context: :registration)
+        flash[:succces] = "編集しました"
+        redirect_to @user
+    elsif user_params[:avatar && :profile_image && :introduction].present?
+        @user.update(user_params)
+        flash[:succces] = "編集しました"
+        redirect_to @user
     else
       render 'edit'
     end
@@ -76,7 +71,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :introduction, :profile_image, :avatar)
   end
 
   def logged_in_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, on: :registration
 
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,14 +1,24 @@
-<div class="back-1 col-md-4 col-md-offset-2">
+<div class="col-md-4 col-md-offset-2">
+  <h3>プロフィール編集</h3>
+  <%= form_with model: @user, local: true do |f|%>
+    <%= f.file_field :profile_image %>
+    <%= f.file_field :avatar %>
+    <%= f.text_field :introduction, class:'form-control'%>
+    <%= f.submit "編集", class: "btn btn-dark w-100" %>
+  <% end %>
+</div>
+<div class="col-md-4 col-md-offset-2">
   <h3>ユーザー編集</h3>
-    <%= form_with model: @user, local: true do |f|%>
-      <%= f.file_field :profile_image %>
-      <%= f.file_field :avatar %>
-      <%= render 'shared/error_messeges', object: f.object%>
-      <%= f.submit "編集", class: "btn btn-dark w-100" %>
-    <% end %>
-     <div class="gravatar_edit">
-      <%= gravatar_for @user %>
-      <a href="http://gravatar.com/emails" target="_blank">change</a>
-    </div>
-  </div>
+  <%= form_for(@user) do |f| %>
+    <%= render 'shared/error_messeges', object: f.object%>
+    <%= f.label :name,"ユーザー名"%>
+    <%= f.text_field :name, class:'form-control'%>
+    <%= f.label :email %>
+    <%= f.email_field :email, class:'form-control'%>
+    <%= f.label :password,"パスワード"%>
+    <%= f.password_field :password, class: 'form-control' %>
+    <%= f.label :password_confirmation,"パスワード確認" %>
+    <%= f.password_field :password_confirmation,class: 'form-control'%>
+    <%= f.submit "編集", class: "btn btn-dark w-100" %>
+  <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,6 +33,7 @@
         <%= render partial: 'users/follow_unfollow', locals: { user: @user } %>
       </div>
     </div>
+    <%= @user.introduction%>
   </div>
 </div>
 <% @microposts.each_with_index do |micropost, i| %>

--- a/db/migrate/20200926125455_add_column_integration.rb
+++ b/db/migrate/20200926125455_add_column_integration.rb
@@ -1,0 +1,5 @@
+class AddColumnIntegration < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :integration, :string
+  end
+end

--- a/db/migrate/20200926130015_add_column_introduction.rb
+++ b/db/migrate/20200926130015_add_column_introduction.rb
@@ -1,0 +1,9 @@
+class AddColumnIntroduction < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :introduction, :string
+  end
+  
+  def down
+    remove_column :users, :integration, :string
+  end
+end

--- a/db/migrate/20200926130652_remove_introduction_from_users.rb
+++ b/db/migrate/20200926130652_remove_introduction_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveIntroductionFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :introduction, :string
+  end
+end

--- a/db/migrate/20200926130906_remove_integration_from_users.rb
+++ b/db/migrate/20200926130906_remove_integration_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveIntegrationFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :integration, :string
+  end
+end

--- a/db/migrate/20200926131128_add_details_to_users.rb
+++ b/db/migrate/20200926131128_add_details_to_users.rb
@@ -1,0 +1,5 @@
+class AddDetailsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :introduction, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_26_070101) do
+ActiveRecord::Schema.define(version: 2020_09_26_131128) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -53,11 +53,10 @@ ActiveRecord::Schema.define(version: 2020_09_26_070101) do
   end
 
   create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "introduction", null: false
+    t.string "introduction"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "introduction"], name: "index_profiles_on_user_id_and_introduction", unique: true
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
@@ -79,6 +78,7 @@ ActiveRecord::Schema.define(version: 2020_09_26_070101) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
プロフィール文を保存する為、Userモデルにintroductionというカラムを追加。

Userモデルのpasswordのバリデーションを:introduction　:profile_image　:avatarの更新時にはスキップさせる。

updateアクションで、プロフィール編集更新か、ユーザー編集更新なのかをif文で分岐させました。

close #88 