### PR TITLE
プロフィール編集画面、ユーザーネーム変更。#92

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    if @user.save
+    if @user.save(context: :password)
       log_in @user
       flash[:succces] = "新規登録完了しました"
       redirect_to @user
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     @user.attributes = user_params
-    if @user.save(context: :registration)
+    if @user.save(context: :password)
         flash[:succces] = "編集しました"
         redirect_to @user
     elsif user_params[:avatar && :profile_image && :introduction].present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }, on: :registration
+  validates :password, presence: true, length: { minimum: 6 }, on: :password
 
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,8 +1,22 @@
 <div class="col-md-4 col-md-offset-2">
   <h3>プロフィール編集</h3>
   <%= form_with model: @user, local: true do |f|%>
+    <% if @user.errors.any? %>
+      <div id="error_explanation">
+        <ul>
+          <% @user.errors.full_messages_for(:name).each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <%= f.label :profile_image,"プロフィール画像"%>
     <%= f.file_field :profile_image %>
+    <%= f.label :avatar,"アイコン画像"%>
     <%= f.file_field :avatar %>
+    <%= f.label :name,"ユーザー名"%>
+    <%= f.text_field :name, class:'form-control'%>
+    <%= f.label :introduction,"自己紹介"%>
     <%= f.text_field :introduction, class:'form-control'%>
     <%= f.submit "編集", class: "btn btn-dark w-100" %>
   <% end %>


### PR DESCRIPTION
プロフィール編集画面で、ユーザーネームを変更出来る様にしました。

ユーザーネームは、空白での更新が出来ない様に、バリデーションはスキップさせてません。

Viewにユーザーネームのみ、エラー表示が出る様にしました。

close #92 