### PR TITLE
プロフィール編集画面、画像削除機能実装。#100

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :currect_user, only: [:edit, :update]
   before_action :admin_user, only: :destroy
   before_action :set_users, only: [:following, :followers]
+  before_action :set_delete, only: [:delete_profile_image, :delete_avatar]
 
   def index
     @users = User.includes(avatar_attachment: :blob).paginate(page: params[:page])
@@ -54,6 +55,12 @@ class UsersController < ApplicationController
     redirect_to users_url
   end
 
+  def delete_profile_image
+  end
+
+  def delete_avatar
+  end
+
   def following
   end
 
@@ -69,6 +76,13 @@ class UsersController < ApplicationController
     @users = users.paginate(page: params[:page])
     render 'show_follow'
   end
+
+  def set_delete
+    @user = User.find(params[:id])
+    action_name == 'delete_profile_image' ? @user.profile_image.purge : @user.avatar.purge
+    redirect_to @user
+  end
+
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :introduction, :profile_image, :avatar)

--- a/app/views/users/_edit.html.erb
+++ b/app/views/users/_edit.html.erb
@@ -5,15 +5,17 @@
         <div class="image_container">
           <span class="edit"><%= f.submit "更新", class: "btn-border-sm" %></span>
           <div id="user-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
-          <% if @user.profile_image.attached? %>
-            <%= image_tag @user.profile_image.variant(resize: "400x400").processed, class: "image", id: :img_prev %>
-          <% end %>
+            <% if @user.profile_image.attached? %>
+              <%= image_tag @user.profile_image.variant(resize: "400x400").processed, class: "image", id: :img_prev %>
+              <%= link_to '削除', delete_profile_image_user_path, method: :delete, data: { confirm: 'プロフィール画像削除しますか?' } %>
+            <% end %>
           <label class="label">
             <i class="fa fa-image" ><%= f.file_field :profile_image, id: :user_img %></i>
           </label>
           <div class="avater_container_modal">
             <% if @user.avatar.attached? %>
               <%= image_tag @user.avatar.variant(resize: "100x100").processed, class: "avatar_profile", id: :avatar_prev %>
+              <%= link_to '削除', delete_avatar_user_path, method: :delete, data: { confirm: 'アバター画像削除しますか?' } %>
             <% else %>
               <%= gravatar_profile @user %>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :users do
     member do
       get :following, :followers
+      delete :delete_profile_image, :delete_avatar
     end
   end
   resources :microposts


### PR DESCRIPTION
プロフィール編集画面で、アバター画像、プロフィール画像、を削除出来る様にしました。

アクションにリクエストが行くと、before_actionでset_deleteに行く様にし、

if文の分岐ででdelete_profile_imageか、delete_avatarでpurgeする内容を変更しています。

close #100 