### PR TITLE
プロフィール編集画面（モーダル）エラー表示#108

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -557,9 +557,13 @@ background-image: linear-gradient(315deg, #fee2f8 0%, #dcf8ef 74%);
   }
   .profile_user_info_modal {
     display: flex;
-    margin:4% 31% 4%;
-     .user_name p {
-      font-size: large;
+    margin:4% 25% 4%;
+     .user_name {
+      width: 100%;
+      text-align: center;
+      p {
+        font-size: large;
+      }
     }
     .follow {
       text-align: center;

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,38 +1,81 @@
-<div class="col-md-4 col-md-offset-2">
-  <h3>プロフィール編集</h3>
-  <%= form_with model: @user, local: true do |f|%>
-    <% if @user.errors.any? %>
-      <div id="error_explanation">
-        <ul>
-          <% @user.errors.full_messages_for(:name).each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
+<%= form_with model: @user, local: true do |f|%>
+  <div class="modal-dialog">
+    <div class="profile_modal col-md-10 col-md-offset-2">
+      <div class="profile_container">
+        <div class="image_container">
+          <span class="edit"><%= f.submit "更新", class: "btn-border-sm" %></span>
+          <div id="user-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
+            <% if @user.profile_image.attached? %>
+              <%= image_tag @user.profile_image.variant(resize: "400x400").processed, class: "image", id: :img_prev %>
+            <% else %>
+              <%= image_tag '/noimage.png', alt: 'プロフィール画像',class: "image", id: :img_prev %>
+            <% end %>
+          <label class="label">
+            <i class="fa fa-image" ><%= f.file_field :profile_image, id: :user_img %></i>
+            <%= link_to '削除', delete_profile_image_user_path, method: :delete, data: { confirm: 'プロフィール画像削除しますか?' } %>
+          </label>
+          <div class="avater_container_modal">
+            <% if @user.avatar.attached? %>
+              <%= image_tag @user.avatar.variant(resize: "100x100").processed, class: "avatar_profile", id: :avatar_prev %>
+            <% else %>
+              <%= gravatar_profile @user %>
+            <% end %>
+            <label class="label">
+              <i class="fa fa-image" ><%= f.file_field :avatar, id: :avatar_img %></i>
+              <%= link_to '削除', delete_avatar_user_path, method: :delete, data: { confirm: 'アバター画像削除しますか?' } %>
+            </label>
+          </div>
+        </div>
+        <div class="profile_user_info_modal">
+          <div class="user_name">
+            <%= f.label :name,"ユーザー名"%>
+            <%= f.text_field :name, class:'form-control'%>
+            <% if @user.errors.any? %>
+              <div id="error_explanation">
+                <ul>
+                  <% @user.errors.full_messages_for(:name).each do |msg| %>
+                    <li><%= msg %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="introduction">
+          <%= f.label :introduction,"自己紹介"%>
+          <%= f.text_area :introduction, placeholder: "自己紹介文を記入して下さい",class: 'form-control'%>
+        </div>
       </div>
-    <% end %>
-    <%= f.label :profile_image,"プロフィール画像"%>
-    <%= f.file_field :profile_image %>
-    <%= f.label :avatar,"アイコン画像"%>
-    <%= f.file_field :avatar %>
-    <%= f.label :name,"ユーザー名"%>
-    <%= f.text_field :name, class:'form-control'%>
-    <%= f.label :introduction,"自己紹介"%>
-    <%= f.text_field :introduction, class:'form-control'%>
-    <%= f.submit "編集", class: "btn btn-dark w-100" %>
-  <% end %>
-</div>
-<div class="col-md-4 col-md-offset-2">
-  <h3>ユーザー編集</h3>
-  <%= form_for(@user) do |f| %>
-    <%= render 'shared/error_messeges', object: f.object%>
-    <%= f.label :name,"ユーザー名"%>
-    <%= f.text_field :name, class:'form-control'%>
-    <%= f.label :email %>
-    <%= f.email_field :email, class:'form-control'%>
-    <%= f.label :password,"パスワード"%>
-    <%= f.password_field :password, class: 'form-control' %>
-    <%= f.label :password_confirmation,"パスワード確認" %>
-    <%= f.password_field :password_confirmation,class: 'form-control'%>
-    <%= f.submit "編集", class: "btn btn-dark w-100" %>
-  <% end %>
-</div>
+    </div>
+  </div>
+<% end %>
+<script type="text/javascript">
+  $(function() {
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+    $('#img_prev').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+        }
+    }
+    $("#user_img").change(function(){
+        readURL(this);
+    });
+  });
+  $(function() {
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+    $('#avatar_prev').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+        }
+    }
+    $("#avatar_img").change(function(){
+        readURL(this);
+    });
+  });
+</script>


### PR DESCRIPTION
プロフィール編集時、name属性のみバリデーションを設定しているので、

エラー表示をモーダル画面で表示させたかったが、
https://github.com/yamken314/Judgement_app/pull/54#issue-487764568

と同様に、エラー時はedit画面へ遷移させる形にしました。

今後、JavaScriptを学習してモーダル上で表示させる予定。