### PR TITLE
投稿編集画面、画像選択時、プレビュー機能実装#112

### DIFF
--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -36,21 +36,19 @@ class MicropostsController < ApplicationController
     else
       render 'show'
     end
-    if image = params[:micropost][:image_ids]
-      image.each do |image_id|
-        @micropost.images.find(image_id).purge
-      end
+    if image = params[:micropost][:image_id]
+      @micropost.image.purge
     end
   end
 
   private
 
     def micropost_params
-      params.require(:micropost).permit(:content, images: [], choices_attributes: [:id,:name, :user_id, :_destroy])
+      params.require(:micropost).permit(:content, :image, choices_attributes: [:id,:name, :user_id, :_destroy])
     end
 
     def set_micropost
-      @micropost = Micropost.with_attached_images.find(params[:id])
+      @micropost = Micropost.with_attached_image.find(params[:id])
       @choice = @micropost.choices.eager_load(:user)
     end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,6 @@
 class StaticPagesController < ApplicationController
   def home
-    @microposts = Micropost.all.includes(:choices, user: {avatar_attachment: :blob}).with_attached_images.sorted_desc
+    @microposts = Micropost.all.includes(:choices, user: {avatar_attachment: :blob}).with_attached_image.sorted_desc
     @colors = ['post_details_1','post_details_2', 'post_details_3', 'post_details_4']
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @microposts = @user.microposts.all.includes(:choices).with_attached_images.sorted_desc
+    @microposts = @user.microposts.all.includes(:choices).with_attached_image.sorted_desc
     @colors = ['post_details_1','post_details_2', 'post_details_3', 'post_details_4']
   end
   

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -2,7 +2,7 @@ class Micropost < ApplicationRecord
   belongs_to :user
   has_many :choices
   scope :sorted_desc, -> { order(created_at: :desc) }
-  has_many_attached :images
+  has_one_attached :image
   validates :content, presence: true, length: { maximum: 140 }
   accepts_nested_attributes_for :choices, allow_destroy: true
 end

--- a/app/views/microposts/_edit.html.erb
+++ b/app/views/microposts/_edit.html.erb
@@ -6,12 +6,14 @@
         <%= gravatar_for @micropost.user %>
         <span class="user"><%= @micropost.user.name %></span>
       </div>
-      <% if @micropost.image.attached? %>
-        <div class="picture">
+      <div class="picture">
+        <% if @micropost.image.attached? %>
           <%= image_tag @micropost.image, class: "img", id: :img_prev %>
           <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_id, {:multiple => true}, @micropost.image.id, false %></p>
-        </div>
-      <% end %>
+        <% else %>
+          <%= image_tag '/noimage.png', alt: 'プロフィール画像',class: "img", id: :img_prev %>
+        <% end %>
+      </div>
       <label class="label">
         <i class="fa fa-image" ><%= f.file_field :image, id: :user_img %></i>
       </label>

--- a/app/views/microposts/_edit.html.erb
+++ b/app/views/microposts/_edit.html.erb
@@ -6,16 +6,14 @@
         <%= gravatar_for @micropost.user %>
         <span class="user"><%= @micropost.user.name %></span>
       </div>
-      <% if @micropost.images.attached? %>
-        <% @micropost.images.each do |image| %>
-          <div class="picture">
-            <%= image_tag image, class: "img", id: :img_prev %>
-            <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_ids, {:multiple => true, class: "hoge"}, image.id, false %></p>
-          </div>
-        <% end %>
+      <% if @micropost.image.attached? %>
+        <div class="picture">
+          <%= image_tag @micropost.image, class: "img", id: :img_prev %>
+          <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_id, {:multiple => true}, @micropost.image.id, false %></p>
+        </div>
       <% end %>
       <label class="label">
-        <i class="fa fa-image" ><%= f.file_field :images, id: :user_img %></i>
+        <i class="fa fa-image" ><%= f.file_field :image, id: :user_img %></i>
       </label>
       <%= f.text_area :content, placeholder: "コメントを記入して下さい",class: "content" %>
       <div id="detail-association-insertion-point">

--- a/app/views/microposts/_edit.html.erb
+++ b/app/views/microposts/_edit.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-dialog">
-  <%= form_with model: @micropost, local: true do |f|%>
+  <%= form_with model: @micropost, local: true do |f| %>
     <div class="sign_up col-md-8 col-md-offset-2">
-      <%= render 'shared/error_messeges', object: f.object%>
+      <%= render 'shared/error_messeges', object: f.object %>
       <div class= "user_info">
         <%= gravatar_for @micropost.user %>
         <span class="user"><%= @micropost.user.name %></span>
@@ -9,12 +9,14 @@
       <% if @micropost.images.attached? %>
         <% @micropost.images.each do |image| %>
           <div class="picture">
-            <%= image_tag image, class: "img" %>
+            <%= image_tag image, class: "img", id: :img_prev %>
             <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_ids, {:multiple => true, class: "hoge"}, image.id, false %></p>
           </div>
         <% end %>
       <% end %>
-      <%= f.file_field :images, multiple: true %>
+      <label class="label">
+        <i class="fa fa-image" ><%= f.file_field :images, id: :user_img %></i>
+      </label>
       <%= f.text_area :content, placeholder: "コメントを記入して下さい",class: "content" %>
       <div id="detail-association-insertion-point">
         <div class="judgement-btn">
@@ -33,3 +35,19 @@
     </div>
   <% end %>
 </div>
+<script type="text/javascript">
+  $(function() {
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+    $('#img_prev').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+        }
+    }
+    $("#user_img").change(function(){
+        readURL(this);
+    });
+  });
+</script>

--- a/app/views/microposts/_new_post.html.erb
+++ b/app/views/microposts/_new_post.html.erb
@@ -5,7 +5,7 @@
       <div class="picture">
         <%= image_tag '/noimage.png', alt: 'プロフィール画像',class: "img", id: :img_prev %>
         <label class="label">
-          <i class="fa fa-image" ><%= f.file_field :images, multiple: true, id: :user_img %></i>
+          <i class="fa fa-image" ><%= f.file_field :image, id: :user_img %></i>
         </label>
       </div>
       <div class="field col-md-12">

--- a/app/views/microposts/edit.html.erb
+++ b/app/views/microposts/edit.html.erb
@@ -6,15 +6,13 @@
         <%= gravatar_for @micropost.user %>
         <span class="user"><%= @micropost.user.name %></span>
       </div>
-      <% if @micropost.images.attached? %>
-        <% @micropost.images.each do |image| %>
-          <div class="picture">
-            <%= image_tag image, class: "img" %>
-            <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_ids, {:multiple => true, class: "hoge"}, image.id, false %></p>
-          </div>
-        <% end %>
+      <% if @micropost.image.attached? %>
+        <div class="picture">
+          <%= image_tag @micropost.image, class: "img" %>
+          <p class="img_check">削除する画像はチェックしてください<%= f.check_box :image_ids, {:multiple => true, class: "hoge"}, @micropost.image.id, false %></p>
+        </div>
       <% end %>
-      <%= f.file_field :images, multiple: true %>
+      <%= f.file_field :image, multiple: true %>
       <%= f.text_area :content, placeholder: "コメントを記入して下さい",class: "content" %>
       <%= render 'shared/error_messeges', object: f.object%>
       <div id="detail-association-insertion-point">

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -13,12 +13,10 @@
       <% end %>
       <span class="user"><%= @micropost.user.name %></span>
     </div>
-      <% if @micropost.images.attached? %>
-        <% @micropost.images.each do |image| %>
-          <div class="picture">
-            <%= image_tag image, class: "img" %>
-          </div>
-        <% end %>
+      <% if @micropost.image.attached? %>
+        <div class="picture">
+          <%= image_tag @micropost.image, class: "img" %>
+        </div>
       <% end %>
     <div class="comment">
       <p><%= @micropost.content %></p>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -9,12 +9,10 @@
           <% end %>
           <span class="user"><%= link_to micropost.user.name, micropost_path(micropost) %></span>
         </div>
-          <% if micropost.images.attached? %>
-            <% micropost.images.each do |image| %>
-              <div class="picture">
-                <%= image_tag image.variant(resize: "500x500").processed, class: "img" %>
-              </div>
-            <% end %>
+          <% if micropost.image.attached? %>
+            <div class="picture">
+              <%= image_tag micropost.image.variant(resize: "500x500").processed, class: "img" %>
+            </div>
           <% end %>
         <div class="comment">
           <p><%= micropost.content %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -54,8 +54,8 @@
           <% end %>
           <span class="user"><%= link_to micropost.user.name, micropost_path(micropost) %></span>
         </div>
-          <% if micropost.images.attached? %>
-            <% micropost.images.each do |image| %>
+          <% if micropost.image.attached? %>
+            <% micropost.image.each do |image| %>
               <div class="picture">
                 <%= image_tag image.variant(resize: "500x500"), class: "img" %>
               </div>


### PR DESCRIPTION
投稿編集画面で画像選択した時、プレビュー出来なかったのでプレビュー機能を実装しました。

複数画像の場合、プレビュー機能が上手く表示されなかったので、micropostsにアタッチされているhas_many_attached :images

を、has_one_attached :imageの単数形に変更してプレビューを表示させる様にしました。

今後、複数形の画像をプレビュー出来る様に実装する予定です。

close #112 