### PR TITLE
choiceボタンの編集ボタン修正。#115

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,6 @@
 class StaticPagesController < ApplicationController
   def home
-    @microposts = Micropost.all.includes(:choices, user: {avatar_attachment: :blob}).with_attached_image.sorted_desc
+    @microposts = Micropost.all.eager_load(user: {avatar_attachment: :blob}).with_attached_image.sorted_desc
     @colors = ['post_details_1','post_details_2', 'post_details_3', 'post_details_4']
   end
 

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -38,12 +38,6 @@
       <div class="choice_show_row">
         <div id="choice_<%= choice.id %>">
           <%= render 'static_pages/choice', choice: choice %>
-          <div class="judgement-btn">
-            <% if choice.micropost.user != current_user && choice.user == current_user %>
-              <%= link_to '編集', edit_choice_path(choice.id), remote: true, class: "btn-border-sm"%>
-              <div id="user-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
-            <% end %>
-          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/static_pages/_choice.html.erb
+++ b/app/views/static_pages/_choice.html.erb
@@ -7,3 +7,8 @@
     <%= link_to choice.name, choice_vote_path(choice.id), method: :post, remote: true %>
   </button>
 <% end %>
+<div class="judgement-btn">
+  <% if choice.micropost.user != current_user && choice.user == current_user %>
+    <%= link_to '編集', edit_choice_path(choice.id), remote: true, class: "btn-border-sm"%>
+  <% end %>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -18,7 +18,7 @@
           <p><%= micropost.content %></p>
         </div>
         <div class="row">
-          <% micropost.choices&.each do |choice| %>
+          <% micropost.choices.eager_load(:user)&.each do |choice| %>
             <div id="choice_<%= choice.id %>">
               <%= render 'choice', choice: choice %>
             </div>


### PR DESCRIPTION
自分以外(他のユーザー)の投稿に、choiceボタンを追加すると

そのchoiceボタンは作成したユーザーが編集出来る様に編集ボタンを表示する仕様にしている。

choiceボタンを押すとAjax処理後、編集ボタンが消えてしまうので、修正しました。

Ajax処理後にレンダリングするパーシャル(_choice.html.erb)の中に編集ボタンを設置する事で修正しました。

その後、編集ボタン内でchoice.userでN+1が発生したので、eager_loadを使用して解消しました。

