### PR TITLE
twitterログイン実装。#130

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-SECRET_KEY_BASE=227cf3165cfc40801578520a0ccb2be6715eb506954360364cdf0cb632c946ef2816d35cc3838775911d6288132dee49e17c286c46670b7fbcf4b3b8c3d6af7b
-DB_NAME=fudgement_production
-DB_USERNAME=root
-DB_PASSWORD=password
-DB_HOSTNAME=judgement-app.cq8ci0oy9stf.ap-northeast-1.rds.amazonaws.com

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /public/uploads
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'cocoon'
 gem 'image_processing', '~> 1.2'
 gem 'kaminari'
 gem 'aws-sdk-s3'
+gem 'omniauth'
+gem 'omniauth-twitter'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,7 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -353,6 +354,16 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     optimist (3.0.1)
     ovirt-engine-sdk (4.4.0)
       json (>= 1, < 3)
@@ -553,6 +564,8 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)
   mysql2 (= 0.4.10)
+  omniauth
+  omniauth-twitter
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,8 +3,15 @@ class SessionsController < ApplicationController
   end
 
   def create
-    @user = User.find_by(email: params[:session][:email].downcase)
-    if @user && @user.authenticate(params[:session][:password])
+    auth = request.env['omniauth.auth']
+    if auth.present?
+      @user = User.find_or_create_from_auth(request.env['omniauth.auth'])
+      session[:user_id] = @user.id
+      flash[:notice] = "ユーザー認証が完了しました。"
+      redirect_to root_path
+    elsif
+      @user = User.find_by(email: params[:session][:email].downcase)
+      @user && @user.authenticate(params[:session][:password])
       log_in @user
       params[:session][:remember_me] == '1'? remember(@user) : forget(@user)
       redirect_to @user

--- a/app/views/sessions/_login.html.erb
+++ b/app/views/sessions/_login.html.erb
@@ -12,6 +12,7 @@
     <div class="guest_login">
       <%= f.submit "ログイン", class: "btn-border" %>
       <%= link_to 'ゲストログイン', guest_sign_in_path, class: "btn-border", method: :post %>
+      <%= link_to "Twitterアカウントでログイン", "/auth/twitter" %>
     </div>
   <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,6 +13,7 @@
     <div class="guest_login">
       <%= f.submit "ログイン", class: "btn-border" %>
       <%= link_to 'ゲストログイン', guest_sign_in_path, class: "btn-border", method: :post %>
+      <%= link_to "Twitterアカウントでログイン", "/auth/twitter" %>
     </div>
   <% end %>
 </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete '/login', to: 'sessions#destroy'
   post '/guest_sign_in', to: 'sessions#new_guest'
+  get 'auth/:provider/callback', to: 'sessions#create'
   resources :users do
     member do
       get :following, :followers

--- a/db/migrate/20201011135149_add_columns_to_users.rb
+++ b/db/migrate/20201011135149_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :uid, :string
+    add_column :users, :provider, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_26_131128) do
+ActiveRecord::Schema.define(version: 2020_10_11_135149) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 2020_09_26_131128) do
     t.string "remember_digest"
     t.boolean "admin", default: false
     t.string "introduction"
+    t.string "uid"
+    t.string "provider"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
ログイン方法をtwitterAPIを導入して、twitterログイン出来る様に実装しました。

Usersモデルに、uid、providerカラムを追加し、find_or_create_byを使い、Usersモデルになければ、

登録する。そのままだと、既存のバリデーションに引っかかるので、

password、email、nameはスキップする様に設定しました。

close #130 