### PR TITLE
Twitterログイン時アイコン画像取得、ActiveStorageに保存。#132

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,8 @@ class User < ApplicationRecord
     votes.where(choice_id: choice.id).exists?
   end
 
+  private
+  
   def self.guest
     find_or_create_by!(name: 'ゲスト',email: 'guest1@example.com') do |user|
       user.password = SecureRandom.urlsafe_base64
@@ -79,9 +81,22 @@ class User < ApplicationRecord
     provider = auth[:provider]
     uid = auth[:uid]
     name = auth[:info][:name]
-    
+    image = auth[:info][:image]
+    image_url = auth[:info][:image]
+    uri = URI.parse(image_url)
+    image = uri.open
+    password = SecureRandom.urlsafe_base64
+    email = User.dummy_email(auth)
+  
     self.find_or_create_by(provider: provider, uid: uid) do |user|
       user.name = name
+      user.avatar.attach(io: image, filename: "#{user.name}_profile.png")
+      user.password = password
+      user.email = email
     end
+  end
+
+  def self.dummy_email(auth)
+    "#{auth.uid}-#{auth.provider}@example.com"
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET']
+  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET'],
+  :image_size => 'original'
 end

--- a/db/migrate/20201012172123_add_columns_image_to_users.rb
+++ b/db/migrate/20201012172123_add_columns_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnsImageToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/migrate/20201013112936_remove_users_from_image.rb
+++ b/db/migrate/20201013112936_remove_users_from_image.rb
@@ -1,0 +1,5 @@
+class RemoveUsersFromImage < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_135149) do
+ActiveRecord::Schema.define(version: 2020_10_13_112936) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
Twitter認証でログインした時に、アイコン画像を取得してActiveStorageに保存する様にしました。

前回のプルリク#130 の修正でログインする際、has_secure_passwordのバリデーションが原因でTwitter認証時弾かれてしまう為

ダミーのパスワードを入れDBに保存するコードを追加しました。

次は、プロフィール編集でTwitterアイコン画像を削除すると、gravatarのアイコンが表示される仕様で

その時にemailが必要になる為、ダミーのemailも一緒にDBに保存する事にしました。

close #132 
