### PR TITLE
Twitter認証キャンセル時、リダイレクト設定。#169

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,4 +32,9 @@ class SessionsController < ApplicationController
     flash[:succces] = "ゲストログインしました。"
     redirect_to root_path
   end
+
+  def failure
+    flash[:notice] = "ログインをキャンセルしました。"
+    redirect_to root_path
+  end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,7 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET'],
   :image_size => 'original'
+  OmniAuth.config.on_failure = Proc.new { |env|
+    OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   delete '/login', to: 'sessions#destroy'
   post '/guest_sign_in', to: 'sessions#new_guest'
   get 'auth/:provider/callback', to: 'sessions#create'
+  get "/auth/failure", to: "sessions#failure"
   resources :users do
     member do
       get :following, :followers


### PR DESCRIPTION
Twitter認証キャンセルすると、エラーが発生していたので、

リダイレクト先を設定しました。

close #169 